### PR TITLE
Refactor setup-gradle tasks

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -25,13 +25,13 @@ jobs:
         working-directory: bash
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - name: Test
-      run: ./test/bats/bin/bats test/hello.bats
+      - name: Test
+        run: ./test/bats/bin/bats test/hello.bats
 
-    - name: Run
-      run: ./src/hello.bash
+      - name: Run
+        run: ./src/hello.bash

--- a/.github/workflows/cobol.yml
+++ b/.github/workflows/cobol.yml
@@ -2,12 +2,12 @@ name: Cobol
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - .github/workflows/cobol.yml
       - cobol/**
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - .github/workflows/cobol.yml
       - cobol/**
@@ -24,35 +24,35 @@ jobs:
         working-directory: cobol
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Configure Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: "8"
-        distribution: "temurin"
+      - name: Configure Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "8"
+          distribution: "temurin"
 
-    - name: Configure Cobol
-      run: |
-        sudo apt-get install -y gnucobol
-        cobc --version
+      - name: Configure Cobol
+        run: |
+          sudo apt-get install -y gnucobol
+          cobc --version
 
-    - name: Test
-      run: ./cobolcheck -p HELLO
+      - name: Test
+        run: ./cobolcheck -p HELLO
 
-    - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
-      with:
-        name: test
-        path: cobol/output/testResults.xml
-        reporter: jest-junit
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: test
+          path: cobol/output/testResults.xml
+          reporter: jest-junit
 
-    - name: Build
-      run: |
-        cobc src/main/cobol/HELLO-CONSOLE.CBL
-        cobc -x src/main/cobol/HELLO.CBL
+      - name: Build
+        run: |
+          cobc src/main/cobol/HELLO-CONSOLE.CBL
+          cobc -x src/main/cobol/HELLO.CBL
 
-    - name: Run
-      run: ./HELLO
+      - name: Run
+        run: ./HELLO

--- a/.github/workflows/cobol.yml
+++ b/.github/workflows/cobol.yml
@@ -2,12 +2,12 @@ name: Cobol
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ main ]
     paths:
       - .github/workflows/cobol.yml
       - cobol/**
   pull_request:
-    branches: [ "main" ]
+    branches: [ main ]
     paths:
       - .github/workflows/cobol.yml
       - cobol/**

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,14 +25,14 @@ jobs:
         working-directory: dotnet
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Configure .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0
-        cache: false
+      - name: Configure .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0
+          cache: false
 
-    - name: Test
-      run: dotnet test -v quiet -l:"console;verbosity=normal"
+      - name: Test
+        run: dotnet test -v quiet -l:"console;verbosity=normal"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,14 +25,14 @@ jobs:
         working-directory: go
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Configure Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go/go.mod'
-        cache: false
+      - name: Configure Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go/go.mod'
+          cache: false
 
-    - name: Test
-      run: go test -test.v
+      - name: Test
+        run: go test -test.v

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -32,7 +32,5 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
         build-root-directory: java

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
 
-    - name: Build
-      run: ./gradlew build
-        build-root-directory: java
+      - name: Build
+        working-directory: java
+        run: ./gradlew build

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -25,18 +25,18 @@ jobs:
         working-directory: javascript
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Configure Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18.x'
-        cache: 'npm'
-        cache-dependency-path: javascript/package-lock.json
+      - name: Configure Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+          cache-dependency-path: javascript/package-lock.json
 
-    - name: Install
-      run: npm install
+      - name: Install
+        run: npm install
 
-    - name: Test
-      run: npm test
+      - name: Test
+        run: npm test

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -32,7 +32,5 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
         build-root-directory: kotlin

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
 
-    - name: Build
-      run: ./gradlew build
-        build-root-directory: kotlin
+      - name: Build
+        working-directory: kotlin
+        run: ./gradlew build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,13 +25,13 @@ jobs:
         working-directory: python
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Configure Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+      - name: Configure Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-    - name: Test
-      run: python -m unittest discover -v
+      - name: Test
+        run: python -m unittest discover -v

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,15 +25,15 @@ jobs:
         working-directory: ruby
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Configure Ruby
-      uses: ruby/setup-ruby@161cd54b698f1fb3ea539faab2e036d409550e3c
-      with:
-        ruby-version: '3'
-        bundler-cache: true
-        working-directory: ruby
+      - name: Configure Ruby
+        uses: ruby/setup-ruby@161cd54b698f1fb3ea539faab2e036d409550e3c
+        with:
+          ruby-version: '3'
+          bundler-cache: true
+          working-directory: ruby
 
-    - name: Test
-      run: bundle exec rspec -fd
+      - name: Test
+        run: bundle exec rspec -fd

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,11 +25,11 @@ jobs:
         working-directory: rust
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Test
-      run: cargo test
+      - name: Test
+        run: cargo test
 
-    - name: Build
-      run: cargo build
+      - name: Build
+        run: cargo build

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -25,21 +25,21 @@ jobs:
         working-directory: scala
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: sbt
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: sbt
 
-    - name: Test
-      run: sbt test
+      - name: Test
+        run: sbt test
 
-      # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
-    - name: Upload Dependency Graph
-      uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e
-      with:
-        working-directory: scala
+        # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
+      - name: Upload Dependency Graph
+        uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e
+        with:
+          working-directory: scala

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,12 +2,12 @@ name: Swift
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - .github/workflows/swift.yml
       - swift/**
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - .github/workflows/swift.yml
       - swift/**

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,12 +2,12 @@ name: Swift
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ main ]
     paths:
       - .github/workflows/swift.yml
       - swift/**
   pull_request:
-    branches: [ "main" ]
+    branches: [ main ]
     paths:
       - .github/workflows/swift.yml
       - swift/**


### PR DESCRIPTION

This job uses deprecated functionality from the gradle/actions/setup-gradle action. Follow the links for upgrade details.
[Using the action to execute Gradle via the `arguments` parameter is deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)